### PR TITLE
Support passing a valid s3client via config

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ module.exports = {
         revisionKey: function(context) {
           var revisionKey = context.revisionData && context.revisionData.revisionKey;
           return context.commandOptions.revision || revisionKey;
+        },
+        s3Client: function(context) {
+          return context.s3Client; // if you want to provide your own S3 client to be used instead of one from aws-sdk
         }
       },
       requiredConfig: ['accessKeyId', 'secretAccessKey', 'bucket'],

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -8,7 +8,7 @@ module.exports = CoreObject.extend({
     var config = plugin.pluginConfig;
     var readConfig = plugin.readConfig;
 
-    this._client                    = new AWS.S3(config);
+    this._client                    = plugin.readConfig('s3Client') || new AWS.S3(config);
     this._bucket                    = plugin.readConfig('bucket');
     this._keyPrefix                 = plugin.readConfig('keyPrefix');
     this._filePattern               = plugin.readConfig('filePattern');


### PR DESCRIPTION
This is the same as how ember-cli-deploy-s3 works, and allows for non-key-and-secret configuration of the aws-sdk.
