### PR TITLE
Handle the case where there is no current.json

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -112,9 +112,13 @@ module.exports = CoreObject.extend({
       var params = { Bucket: bucket, Key: currentRevisionIdentifier };
 
       client.getObject(params, function(err, data) {
-        if (err) {
+        if (err && err.code === 'NoSuchKey') {
+          return resolve();
+        }
+        else if (err) {
           return reject(err);
-        } else {
+        }
+        else {
           var json = JSON.parse(data.Body.toString('utf8'));
 
           return resolve(json.revision);


### PR DESCRIPTION
When we haven't yet written current.json, we get a fatal error from _getCurrentData
