### PR TITLE
Fixing deploy:list

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,33 +57,27 @@ module.exports = {
         }
 
         return this._fetchRevisionsData()
-          .then(this._createRevisionsList)
           .then(this._activateRevision.bind(this, revisionKey));
       },
 
       fetchRevisions: function(context) {
-        return this._fetchRevisionsData();
+        return this._fetchRevisionsData()
+          .then(function(revisions) {
+            context.revisions = revisions;
+          });
       },
 
       _fetchRevisionsData: function() {
         var s3 = new S3({ plugin: this })
 
-        return s3.fetchRevisions()
-          .then(function(revisions) {
-            return { revisions: revisions };
-          });
-      },
-
-      _createRevisionsList: function(revisionsData) {
-        var revisions = revisionsData.revisions;
-
-        return revisions.map(function(r) { return r.revision; });
+        return s3.fetchRevisions();
       },
 
       _activateRevision: function(revisionKey, availableRevisions) {
         this.log('Activating revision `' + revisionKey + '`');
 
-        if (availableRevisions.indexOf(revisionKey) > -1) {
+        var found = availableRevisions.map(function(element) { return element.revision; }).indexOf(revisionKey);
+        if (found >= 0) {
           return this._overwriteCurrentIndex(revisionKey)
             .then(this._updateCurrentRevisionPointer.bind(this, revisionKey));
         } else {

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -74,7 +74,7 @@ module.exports = CoreObject.extend({
     return revisionsData.map(function(d) {
       var revision = d.Key;
 
-      return { revision: revision, active: revision === currentRevision };
+      return { revision: revision, timestamp: d.LastModified, active: revision === currentRevision };
     });
   },
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -12,7 +12,6 @@ module.exports = CoreObject.extend({
     this._bucket                    = plugin.readConfig('bucket');
     this._keyPrefix                 = plugin.readConfig('keyPrefix');
     this._filePattern               = plugin.readConfig('filePattern');
-    this._currentRevisionIdentifier = plugin.readConfig('currentRevisionIdentifier');
   },
 
   fetchRevisions: function() {
@@ -77,11 +76,11 @@ module.exports = CoreObject.extend({
 
   _createRevisionDataFromList: function(data) {
     const revisionsData   = this._sortBucketContents(data.revisions).Contents;
-    const currentRevision = data.current;
+    const currentETag = data.current;
 
     return revisionsData.map(function(d) {
       var revision = this._removeKeyPrefix(d.Key);
-      return { revision: revision, timestamp: d.LastModified, active: revision === currentRevision };
+      return { revision: revision, timestamp: d.LastModified, active: d.ETag === currentETag };
     }.bind(this));
   },
 
@@ -111,14 +110,14 @@ module.exports = CoreObject.extend({
   },
 
   _getCurrentData: function() {
-    var client                    = this._client;
-    var bucket                    = this._bucket;
-    var currentRevisionIdentifier = this._currentRevisionIdentifier;
+    var client      = this._client;
+    var bucket      = this._bucket;
+    var filePattern = this._filePattern;
 
     return new Promise(function(resolve, reject) {
-      var params = { Bucket: bucket, Key: currentRevisionIdentifier };
+      var params = { Bucket: bucket, Key: filePattern };
 
-      client.getObject(params, function(err, data) {
+      client.headObject(params, function(err, data) {
         if (err && err.code === 'NoSuchKey') {
           return resolve();
         }
@@ -126,8 +125,7 @@ module.exports = CoreObject.extend({
           return reject(err);
         }
         else {
-          var json = JSON.parse(data.Body.toString('utf8'));
-          return resolve(json.revision);
+          return resolve(data.ETag);
         }
       });
     });

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -67,15 +67,22 @@ module.exports = CoreObject.extend({
     });
   },
 
+  _removeKeyPrefix: function(key) {
+    const keyPrefix = this._keyPrefix;
+    if (key.indexOf(keyPrefix + ":") === 0) {
+      key = key.substr(keyPrefix.length+1);
+    }
+    return key;
+  },
+
   _createRevisionDataFromList: function(data) {
     const revisionsData   = this._sortBucketContents(data.revisions).Contents;
     const currentRevision = data.current;
 
     return revisionsData.map(function(d) {
-      var revision = d.Key;
-
+      var revision = this._removeKeyPrefix(d.Key);
       return { revision: revision, timestamp: d.LastModified, active: revision === currentRevision };
-    });
+    }.bind(this));
   },
 
   _sortBucketContents: function(data) {
@@ -120,7 +127,6 @@ module.exports = CoreObject.extend({
         }
         else {
           var json = JSON.parse(data.Body.toString('utf8'));
-
           return resolve(json.revision);
         }
       });


### PR DESCRIPTION
This change:
- fixes fetchRevisions to fill out the revision property of revisions
- leverages S3 ETags to track active revision, removes the need for current.json
- adds the revision timestamp property using the s3 LastModified date
- displays revision without the keyPrefix, to match what deploy:active expects
