### PR TITLE
Large restructure of s3-index plugin

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -1,129 +1,107 @@
 var AWS        = require('aws-sdk');
 var CoreObject = require('core-object');
 var Promise    = require('ember-cli/lib/ext/promise');
+var fs         = require('fs');
+var path       = require('path');
+var readFile   = Promise.denodeify(fs.readFile);
+
+var headObject = function(client, params) {
+  return new Promise(function(resolve, reject) {
+    client.headObject(params, function(err, data) {
+      if (err && err.code === 'NotFound') {
+        return resolve();
+      }
+      else if (err) {
+        return reject(err);
+      }
+      else {
+        return resolve(data);
+      }
+    });
+  });
+}
 
 module.exports = CoreObject.extend({
   init: function(options) {
     var plugin = options.plugin;
     var config = plugin.pluginConfig;
-    var readConfig = plugin.readConfig;
 
-    this._client                    = plugin.readConfig('s3Client') || new AWS.S3(config);
-    this._bucket                    = plugin.readConfig('bucket');
-    this._keyPrefix                 = plugin.readConfig('keyPrefix');
-    this._filePattern               = plugin.readConfig('filePattern');
-    this._currentRevisionIdentifier = plugin.readConfig('currentRevisionIdentifier');
+    this._plugin = plugin;
+    this._client = plugin.readConfig('s3Client') || new AWS.S3(config);
   },
 
-  fetchRevisions: function() {
-    return Promise.hash({
-      revisions: this._getBucketContents(),
-      current: this._getCurrentData()
-    })
-    .then(this._createRevisionDataFromList.bind(this));
-  },
-
-  upload: function(key, fileContent) {
-    var client = this._client;
+  upload: function(options) {
+    var client    = this._client;
+    var plugin    = this._plugin;
+    var bucket    = options.bucket;
+    var acl       = options.acl || 'public-read';
+    var key       = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
+    var putObject = Promise.denodeify(client.putObject.bind(client));
 
     var params = {
-      Bucket: this._bucket,
+      Bucket: bucket,
       Key: key,
-      Body: fileContent,
+      ACL: acl,
       ContentType: 'text/html',
       CacheControl: 'max-age=0, no-cache'
     }
 
-    return new Promise(function(resolve, reject) {
-      client.putObject(params, function(err, data) {
-        if (err) {
-          return reject(err);
-        } else {
-          return resolve(data);
-        }
-      });
+    return readFile(options.filePath).then(function(fileContents) {
+      params.Body = fileContents;
+      return putObject(params).then(function() {
+        plugin.log('✔  ' + key);
+      })
     });
   },
 
-  overwriteCurrentIndex: function(newRevisionKey) {
-    var client     = this._client;
-    var bucket     = this._bucket;
-    var copySource = encodeURIComponent(bucket+'/'+newRevisionKey);
+  activate: function(options) {
+    var plugin      = this._plugin;
+    var client      = this._client;
+    var bucket      = options.bucket;
+    var acl         = options.acl || 'public-read';
+    var revisionKey = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
+    var indexKey    = path.join(options.prefix, options.filePattern);
+    var copySource  = encodeURIComponent(path.join(bucket, revisionKey));
+    var copyObject  = Promise.denodeify(client.copyObject.bind(client));
 
     var params = {
       Bucket: bucket,
       CopySource: copySource,
-      Key: this._filePattern
+      Key: indexKey,
+      ACL: acl,
     };
 
-    return new Promise(function(resolve, reject) {
-      client.copyObject(params, function(err, data) {
-        if (err) {
-          return reject(err);
-        } else {
-          return resolve(data);
-        }
+    return this.fetchRevisions(options).then(function(revisions) {
+      var found = revisions.map(function(element) { return element.revision; }).indexOf(options.revisionKey);
+      if (found >= 0) {
+        return copyObject(params).then(function() {
+          plugin.log('✔  ' + revisionKey + " => " + indexKey);
+        })
+      } else {
+        return Promise.reject("REVISION NOT FOUND!"); // see how we should handle a pipeline failure
+      }
+    });
+  },
+
+  fetchRevisions: function(options) {
+    var client         = this._client;
+    var bucket         = options.bucket;
+    var revisionPrefix = path.join(options.prefix, options.filePattern + ":");
+    var indexKey       = path.join(options.prefix, options.filePattern);
+    var listObjects    = Promise.denodeify(client.listObjects.bind(client));
+
+    return Promise.hash({
+      revisions: listObjects({ Bucket: bucket, Prefix: revisionPrefix }),
+      current: headObject(client, { Bucket: bucket, Key: indexKey }),
+    })
+    .then(function(data) {
+      return data.revisions.Contents.sort(function(a, b) {
+        return new Date(b.LastModified) - new Date(a.LastModified);
+      }).map(function(d) {
+        var revision = d.Key.substr(revisionPrefix.length);
+        var active = data.current && d.ETag === data.current.ETag;
+        return { revision: revision, timestamp: d.LastModified, active: active };
       });
     });
   },
-
-  _createRevisionDataFromList: function(data) {
-    const revisionsData   = this._sortBucketContents(data.revisions).Contents;
-    const currentRevision = data.current;
-
-    return revisionsData.map(function(d) {
-      var revision = d.Key;
-
-      return { revision: revision, active: revision === currentRevision };
-    });
-  },
-
-  _sortBucketContents: function(data) {
-    data.Contents = data.Contents.sort(function(a, b) {
-          return new Date(b.LastModified) - new Date(a.LastModified);
-        });
-    return data;
-  },
-
-  _getBucketContents: function() {
-    var client    = this._client;
-    var keyPrefix = this._keyPrefix;
-    var bucket    = this._bucket;
-
-    return new Promise(function(resolve, reject) {
-      var params = { Bucket: bucket, Prefix: keyPrefix };
-
-      client.listObjects(params, function(err, data) {
-        if (err) {
-          return reject(err);
-        } else {
-          return resolve(data);
-        }
-      });
-    });
-  },
-
-  _getCurrentData: function() {
-    var client                    = this._client;
-    var bucket                    = this._bucket;
-    var currentRevisionIdentifier = this._currentRevisionIdentifier;
-
-    return new Promise(function(resolve, reject) {
-      var params = { Bucket: bucket, Key: currentRevisionIdentifier };
-
-      client.getObject(params, function(err, data) {
-        if (err && err.code === 'NoSuchKey') {
-          return resolve();
-        }
-        else if (err) {
-          return reject(err);
-        }
-        else {
-          var json = JSON.parse(data.Body.toString('utf8'));
-
-          return resolve(json.revision);
-        }
-      });
-    });
-  }
 });


### PR DESCRIPTION
Brings this plugin much more inline with the operation and structure of https://github.com/ember-cli-deploy/ember-cli-deploy-s3
- Cleaner line between index.js and s3.js, like in the s3 plugin
- prefix option support. like the s3 plugin, so you can upload to a subdirectory of a bucket
- keyPrefix is removed. versions are uploaded as `filePattern + ":" + revision`
- leverages S3 ETags to track the active revision, removes the need for current.json
- assigns revision property, fixing `deploy:list`
- `deploy:list` lists revisions in the format expected by `deploy:activate`
- adds the revision timestamp property using the s3 LastModified date
- Uses Promise.denodify to reduce LOC and improve readibility
