### PR TITLE
Add `allowOverwrite` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ The unique revision number for the version of the file being uploaded to S3. The
 
 *Default:* `context.commandLineArgs.revisionKey || context.revisionKey`
 
+### allowOverwrite
+
+A flag to specify whether the revision should be overwritten if it already exists in S3.
+
+*Default:* `false`
+
 ### s3Client
 
 The underlying S3 library used to upload the files to S3. This allows the user to use the default upload client provided by this plugin but switch out the underlying library that is used to actually send the files.

--- a/index.js
+++ b/index.js
@@ -25,16 +25,18 @@ module.exports = {
         },
         s3Client: function(context) {
           return context.s3Client; // if you want to provide your own S3 client to be used instead of one from aws-sdk
-        }
+        },
+        allowOverwrite: false
       },
       requiredConfig: ['accessKeyId', 'secretAccessKey', 'bucket'],
 
       upload: function(context) {
-        var bucket      = this.readConfig('bucket');
-        var prefix      = this.readConfig('prefix');
-        var revisionKey = this.readConfig('revisionKey');
-        var distDir     = this.readConfig('distDir');
-        var filePattern = this.readConfig('filePattern');
+        var bucket         = this.readConfig('bucket');
+        var prefix         = this.readConfig('prefix');
+        var revisionKey    = this.readConfig('revisionKey');
+        var distDir        = this.readConfig('distDir');
+        var filePattern    = this.readConfig('filePattern');
+        var allowOverwrite = this.readConfig('allowOverwrite');
         var filePath    = path.join(distDir, filePattern);
 
         var options = {
@@ -43,6 +45,7 @@ module.exports = {
           filePattern: filePattern,
           filePath: filePath,
           revisionKey: revisionKey,
+          allowOverwrite: allowOverwrite
         };
 
         this.log('preparing to upload revision to S3 bucket `' + bucket + '`');

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -31,12 +31,13 @@ module.exports = CoreObject.extend({
   },
 
   upload: function(options) {
-    var client    = this._client;
-    var plugin    = this._plugin;
-    var bucket    = options.bucket;
-    var acl       = options.acl || 'public-read';
-    var key       = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
-    var putObject = Promise.denodeify(client.putObject.bind(client));
+    var client         = this._client;
+    var plugin         = this._plugin;
+    var bucket         = options.bucket;
+    var acl            = options.acl || 'public-read';
+    var allowOverwrite = options.allowOverwrite;
+    var key            = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
+    var putObject      = Promise.denodeify(client.putObject.bind(client));
 
     var params = {
       Bucket: bucket,
@@ -46,11 +47,20 @@ module.exports = CoreObject.extend({
       CacheControl: 'max-age=0, no-cache'
     }
 
-    return readFile(options.filePath).then(function(fileContents) {
-      params.Body = fileContents;
-      return putObject(params).then(function() {
-        plugin.log('✔  ' + key);
+    return this.fetchRevisions(options)
+      .then(function(revisions) {
+        var found = revisions.map(function(element) { return element.revision; }).indexOf(options.revisionKey);
+        if (found >= 0 && !allowOverwrite) {
+          return Promise.reject("REVISION ALREADY UPLOADED! (set `allowOverwrite: true` if you want to support overwriting revisions)")
+        }
+        return Promise.resolve();
       })
+      .then(readFile.bind(this, options.filePath))
+      .then(function(fileContents) {
+        params.Body = fileContents;
+        return putObject(params).then(function() {
+          plugin.log('✔  ' + key);
+        });
     });
   },
 

--- a/tests/unit/lib/s3-nodetest.js
+++ b/tests/unit/lib/s3-nodetest.js
@@ -74,7 +74,8 @@ describe('s3', function() {
         prefix: '',
         filePattern: filePattern,
         revisionKey: revisionKey,
-        filePath: 'tests/unit/fixtures/test.html'
+        filePath: 'tests/unit/fixtures/test.html',
+        allowOverwrite: false
       };
 
       s3Client.putObject = function(params, cb) {
@@ -151,6 +152,26 @@ describe('s3', function() {
 
           assert.equal(s3Params.ACL, acl, 'acl passed correctly');
         });
+    });
+
+    describe("when revisionKey was already uploaded", function() {
+      beforeEach(function() {
+        options.revisionKey = "123";
+      });
+
+      it('rejects when trying to upload an already uploaded revision', function() {
+        var promise = subject.upload(options);
+
+        return assert.isRejected(promise);
+      });
+
+      it('does not reject when allowOverwrite option is set to true', function() {
+        options.allowOverwrite = true;
+
+        var promise = subject.upload(options);
+
+        return assert.isFulfilled(promise);
+      });
     });
   });
 


### PR DESCRIPTION
Overwriting already uploaded revisions should not be
the default way this plugin works.

There is now an option to opt-in to allow overwriting
already uploaded revisions like it is the case in the
`ember-cli-deploy-redis`-plugin
