### PR TITLE
[WIP] Preview revisions

### DIFF
--- a/addon/instance-initializers/preview-revisions.js
+++ b/addon/instance-initializers/preview-revisions.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+const { $ } = Ember;
+
+export default {
+  name: 'preview-revisions',
+
+  initialize: function() {
+    const regex = new RegExp('(#/)?(index.html:\.*?(?=/|$))', 'i');
+    const locationPartToTest = location.hash ? location.hash : location.pathname;
+
+    var result = regex.exec(locationPartToTest);
+
+    if (result) {
+      var baseHref = result[2];
+
+      $('base').attr('href', `/${baseHref}/`);
+    }
+  }
+};

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
   createDeployPlugin: function(options) {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
+      S3: options.S3 || S3,
 
       defaultConfig: {
         region: 'us-east-1',
@@ -55,7 +56,7 @@ module.exports = {
 
         this.log('preparing to upload revision to S3 bucket `' + bucket + '`');
 
-        var s3 = new S3({ plugin: this });
+        var s3 = new this.S3({ plugin: this });
         return s3.upload(options);
       },
 
@@ -74,8 +75,15 @@ module.exports = {
 
         this.log('preparing to activate `' + revisionKey + '`');
 
-        var s3 = new S3({ plugin: this });
+        var s3 = new this.S3({ plugin: this });
         return s3.activate(options);
+      },
+
+      didActivate: function(context) {
+        var didActivate = this.readConfig('didActivate') || function() {};
+
+        return Promise.resolve()
+          .then(didActivate)
       },
 
       fetchRevisions: function(context) {
@@ -89,7 +97,7 @@ module.exports = {
           filePattern: filePattern,
         };
 
-        var s3 = new S3({ plugin: this });
+        var s3 = new this.S3({ plugin: this });
         return s3.fetchRevisions(options)
           .then(function(revisions) {
             context.revisions = revisions;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = {
         s3Client: function(context) {
           return context.s3Client; // if you want to provide your own S3 client to be used instead of one from aws-sdk
         },
+        cacheControl: 'max-age=0, public',
         allowOverwrite: false
       },
       requiredConfig: ['accessKeyId', 'secretAccessKey', 'bucket'],
@@ -37,7 +38,9 @@ module.exports = {
         var distDir        = this.readConfig('distDir');
         var filePattern    = this.readConfig('filePattern');
         var allowOverwrite = this.readConfig('allowOverwrite');
-        var filePath    = path.join(distDir, filePattern);
+        var cacheControl   = this.readConfig('cacheControl');
+        var metadata       = this.readConfig('metadata');
+        var filePath       = path.join(distDir, filePattern);
 
         var options = {
           bucket: bucket,
@@ -45,7 +48,9 @@ module.exports = {
           filePattern: filePattern,
           filePath: filePath,
           revisionKey: revisionKey,
-          allowOverwrite: allowOverwrite
+          allowOverwrite: allowOverwrite,
+          cacheControl: cacheControl,
+          metadata: metadata
         };
 
         this.log('preparing to upload revision to S3 bucket `' + bucket + '`');

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -35,7 +35,7 @@ module.exports = CoreObject.extend({
     var plugin         = this._plugin;
     var bucket         = options.bucket;
     var acl            = options.acl || 'public-read';
-    var cacheControl   = options.cacheControl || 'max-age=0, no-cache';
+    var cacheControl   = options.cacheControl || 'max-age=0, public';
     var metadata       = options.metadata;
     var allowOverwrite = options.allowOverwrite;
     var key            = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -44,8 +44,12 @@ module.exports = CoreObject.extend({
       Key: key,
       ACL: acl,
       ContentType: 'text/html',
-      CacheControl: 'max-age=0, no-cache'
-    }
+      CacheControl: 'max-age=0, public',
+      Metadata: {
+        "surrogate-control": 'max-age=3600',
+        "surrogate-key": 'index'
+      }
+    };
 
     return this.fetchRevisions(options)
       .then(function(revisions) {

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -35,6 +35,8 @@ module.exports = CoreObject.extend({
     var plugin         = this._plugin;
     var bucket         = options.bucket;
     var acl            = options.acl || 'public-read';
+    var cacheControl   = options.cacheControl || 'max-age=0, no-cache';
+    var metadata       = options.metadata;
     var allowOverwrite = options.allowOverwrite;
     var key            = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
     var putObject      = Promise.denodeify(client.putObject.bind(client));
@@ -44,12 +46,12 @@ module.exports = CoreObject.extend({
       Key: key,
       ACL: acl,
       ContentType: 'text/html',
-      CacheControl: 'max-age=0, public',
-      Metadata: {
-        "surrogate-control": 'max-age=3600',
-        "surrogate-key": 'index'
-      }
+      CacheControl: cacheControl
     };
+
+    if (metadata) {
+      params.Metadata = metadata;
+    }
 
     return this.fetchRevisions(options)
       .then(function(revisions) {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,0 +1,228 @@
+var CoreObject = require('core-object');
+var assert     = require('ember-cli/tests/helpers/assert');
+var Promise    = require('ember-cli/lib/ext/promise');
+
+
+describe('s3-index plugin', function() {
+  var subject, plugin, mockUi, s3Options;
+
+  var DIST_DIR                = 'tmp/dist';
+  var ACCESS_KEY              = 'access';
+  var SECRET                  = 'secret';
+  var BUCKET                  = 'bucket';
+  var REVISION_KEY            = 'revision-key';
+  var DIST_DIR                = 'tmp/dist';
+  var DEFAULT_PREFIX          = '';
+  var DEFAULT_FILE_PATTERN    = 'index.html';
+  var DEFAULT_CACHE_CONTROL   = 'max-age=0, public';
+  var DEFAULT_ALLOW_OVERWRITE = false;
+
+  function s3Stub(options) {
+    s3Options = options;
+    return Promise.resolve();
+  }
+
+  before(function() {
+    subject = require('../../index');
+  });
+
+  beforeEach(function() {
+    s3Options = {};
+
+    mockS3 = CoreObject.extend({
+      upload: s3Stub,
+
+      activate: s3Stub,
+
+      fetchRevisions: s3Stub
+    }),
+
+    plugin = subject.createDeployPlugin({
+      name: 's3-index',
+      S3: mockS3
+    });
+
+    mockUi = {
+      messages: [],
+      write: function() {},
+      writeLine: function(message) {
+        this.messages.push(message);
+      }
+    };
+
+    context = {
+      ui: mockUi,
+
+      commandOptions: {},
+
+      distDir: DIST_DIR,
+
+      revisionData: {
+        revisionKey: REVISION_KEY
+      },
+
+      config: {
+        "s3-index": {
+          accessKeyId: 'access',
+          secretAccessKey: 'secret',
+          bucket: 'bucket'
+        }
+      }
+    }
+  });
+
+  it('it has a name', function() {
+    assert.equal(plugin.name, 's3-index');
+  });
+
+  describe('hooks', function() {
+    beforeEach(function() {
+      plugin.beforeHook(context);
+      plugin.configure(context);
+    });
+
+    describe('#upload', function() {
+      it('implements the `upload`-hook', function() {
+        assert.ok(plugin.upload);
+      });
+
+      it('passes the correct options to the S3-abstraction', function() {
+        var promise = plugin.upload(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            var expected = {
+              bucket: BUCKET,
+              prefix: DEFAULT_PREFIX,
+              filePattern: DEFAULT_FILE_PATTERN,
+              filePath: DIST_DIR+'/'+DEFAULT_FILE_PATTERN,
+              revisionKey: REVISION_KEY,
+              allowOverwrite: false,
+              cacheControl: DEFAULT_CACHE_CONTROL,
+              metadata: undefined
+            };
+
+            assert.deepEqual(s3Options, expected);
+          });
+      });
+
+      it('passes metdata when specified in plugin configuration', function() {
+        var metadata = {
+          "surrogate-key": "index"
+        };
+        context.config['s3-index'].metadata = metadata;
+
+        var promise = plugin.upload(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            var expected = {
+              bucket: BUCKET,
+              prefix: DEFAULT_PREFIX,
+              filePattern: DEFAULT_FILE_PATTERN,
+              filePath: DIST_DIR+'/'+DEFAULT_FILE_PATTERN,
+              revisionKey: REVISION_KEY,
+              allowOverwrite: false,
+              cacheControl: DEFAULT_CACHE_CONTROL,
+              metadata: metadata
+            };
+
+            assert.deepEqual(s3Options, expected);
+          });
+      });
+    });
+
+    describe('#activate', function() {
+      it('implements the `activate`-hook', function() {
+        assert.ok(plugin.activate);
+      });
+
+      it('passes the correct options to the S3-abstraction', function() {
+        context.commandOptions.revision = '1234';
+
+        var promise = plugin.activate(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            var expected = {
+              bucket: BUCKET,
+              prefix: DEFAULT_PREFIX,
+              filePattern: DEFAULT_FILE_PATTERN,
+              revisionKey: '1234'
+            };
+
+            assert.deepEqual(s3Options, expected);
+          });
+      });
+    });
+
+    describe('#didActivate', function() {
+      it('implements the `didActivate`-hook', function() {
+        assert.ok(plugin.didActivate);
+      });
+
+      it('calls a user defined function when `didActivate`-property is present in plugin configuration', function() {
+        var didActivateCalled = false;
+
+        context.config['s3-index'].didActivate = function(context) {
+          return function() {
+            didActivateCalled = true;
+          };
+        };
+
+        var promise = plugin.didActivate(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            assert.isTrue(didActivateCalled);
+          });
+      });
+
+      it('calls a user defined function that has access to the deployment context', function() {
+        var test = 'awesome';
+
+        context.awesome = 'sauce';
+
+        context.config['s3-index'].didActivate = function(deployContext) {
+          return function() {
+            test = test + deployContext.awesome;
+          };
+        };
+
+        var promise = plugin.didActivate(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            assert.equal(test, 'awesomesauce');
+          });
+      });
+
+      it('does not break when no didActivate property is present on plugin configuration', function() {
+        var promise = plugin.didActivate(context);
+
+        return assert.isFulfilled(promise);
+      });
+    });
+
+    describe('#fetchRevisions', function() {
+      it('implements the `fetchRevisions`-hook', function() {
+        assert.ok(plugin.fetchRevisions);
+      });
+
+      it('passes the correct options to the S3-abstraction', function() {
+        var promise = plugin.fetchRevisions(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            var expected = {
+              bucket: BUCKET,
+              prefix: DEFAULT_PREFIX,
+              filePattern: DEFAULT_FILE_PATTERN
+            };
+
+            assert.deepEqual(s3Options, expected);
+          });
+      });
+    });
+  });
+});

--- a/tests/unit/lib/s3-nodetest.js
+++ b/tests/unit/lib/s3-nodetest.js
@@ -119,7 +119,7 @@ describe('s3', function() {
           assert.equal(s3Params.Key, expectedKey, 'Key passed correctly');
           assert.equal(s3Params.ACL, defaultACL, 'ACL defaults to `public-read`');
           assert.equal(s3Params.ContentType, 'text/html', 'contentType is set to `text/html`');
-          assert.equal(s3Params.CacheControl, 'max-age=0, no-cache', 'cacheControl set correctly');
+          assert.equal(s3Params.CacheControl, 'max-age=0, public', 'cacheControl set correctly');
         });
     });
 

--- a/tests/unit/lib/s3-nodetest.js
+++ b/tests/unit/lib/s3-nodetest.js
@@ -154,6 +154,35 @@ describe('s3', function() {
         });
     });
 
+    it('allows `cacheControl` to be passed to customize the CacheControl option', function() {
+      var cacheControl = 'max-age=3600, public';
+
+      options.cacheControl = cacheControl;
+
+      var promise = subject.upload(options);
+
+      return assert.isFulfilled(promise)
+        .then(function() {
+          assert.equal(s3Params.CacheControl, cacheControl);
+        });
+    });
+
+    it('allows `metadata` option to be passed to customize the Metadata set on the uploaded file', function() {
+      var metadata = {
+        "surrogate-control": "max-age=3600",
+        "surrogate-key": "index"
+      };
+
+      options.metadata = metadata;
+
+      var promise = subject.upload(options);
+
+      return assert.isFulfilled(promise)
+        .then(function() {
+          assert.equal(s3Params.Metadata, metadata);
+        });
+    });
+
     describe("when revisionKey was already uploaded", function() {
       beforeEach(function() {
         options.revisionKey = "123";


### PR DESCRIPTION
This PR will make it possible to preview revisions when using `location: 'auto'`. previewing revisions with hash-location was already possible.

This also includes improvements and a README update for using this plugin in combination with CDNs.

Left to do:
- [ ] test for the instance initializer that users can now import into their apps
- [ ] possibility to customize `<file-pattern>` in instance-initializer currently this is hardcoded to `index.html`
- [ ] document caveats when using this plugin without a CDN and using this with CDNs that don't support instant cache invalidation
- [x] add `didActivate`-hook implementation that can be used to invalidate a CDN's caching of the currently activated index.html
