### PR TITLE
Don't use path.join for URLs

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -5,7 +5,7 @@ var fs         = require('fs');
 var path       = require('path');
 var readFile   = Promise.denodeify(fs.readFile);
 
-var headObject = function(client, params) {
+function headObject(client, params) {
   return new Promise(function(resolve, reject) {
     client.headObject(params, function(err, data) {
       if (err && err.code === 'NotFound') {
@@ -19,6 +19,10 @@ var headObject = function(client, params) {
       }
     });
   });
+}
+
+function joinUriSegments(prefix, uri) {
+  return prefix === '' ? uri : [prefix, uri].join('/');
 }
 
 module.exports = CoreObject.extend({
@@ -69,9 +73,13 @@ module.exports = CoreObject.extend({
     var client      = this._client;
     var bucket      = options.bucket;
     var acl         = options.acl || 'public-read';
-    var revisionKey = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
-    var indexKey    = path.join(options.prefix, options.filePattern);
-    var copySource  = encodeURIComponent(path.join(bucket, revisionKey));
+    var prefix      = options.prefix
+    var filePattern = options.filePattern;
+    var key         = filePattern + ":" + options.revisionKey;
+
+    var revisionKey = joinUriSegments(prefix, key);
+    var indexKey    = joinUriSegments(prefix, filePattern);
+    var copySource  = encodeURIComponent([bucket, revisionKey].join('/'));
     var copyObject  = Promise.denodeify(client.copyObject.bind(client));
 
     var params = {
@@ -96,8 +104,9 @@ module.exports = CoreObject.extend({
   fetchRevisions: function(options) {
     var client         = this._client;
     var bucket         = options.bucket;
-    var revisionPrefix = path.join(options.prefix, options.filePattern + ":");
-    var indexKey       = path.join(options.prefix, options.filePattern);
+    var prefix         = options.prefix;
+    var revisionPrefix = joinUriSegments(prefix, options.filePattern + ":");
+    var indexKey       = joinUriSegments(prefix, options.filePattern);
     var listObjects    = Promise.denodeify(client.listObjects.bind(client));
 
     return Promise.hash({


### PR DESCRIPTION
If we rely on `path.join` to join strings with '/' we break
the plugin for windows users as `path.join` inserts `\\` instead
of `/` on windows.

Fixes #25
