### PR TITLE
[Doc] Fix documentation passing revision via cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ The root directory where the file matching `filePattern` will be searched for. B
 
 ### revisionKey
 
-The unique revision number for the version of the file being uploaded to S3. The key will be a combination of the `keyPrefix` and the `revisionKey`. By default this option will use either the `revisionKey` passed in from the command line or the `revisionKey` property from the deployment context.
+The unique revision number for the version of the file being uploaded to S3. The key will be a combination of the `keyPrefix` and the `revisionKey`. By default this option will use either the `revision` passed in from the command line or the `revisionData.revisionKey` property from the deployment context.
 
-*Default:* `context.commandLineArgs.revisionKey || context.revisionKey`
+*Default:* `context.commandOptions.revision || context.revisionData.revisionKey`
 
 ### allowOverwrite
 


### PR DESCRIPTION
Docs are actually wrong about this. Idea is the same but the implementation is different to what's documented. See https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index/blob/master/index.js#L24
