### PR TITLE
add support for didDeployMessage (inspired by redis plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ The client specified MUST implement functions called `getObject` and `putObject`
 
 *Default:* the default S3 library is `aws-sdk`
 
+### didDeployMessage
+
+A message that will be displayed after the index file has been successfully uploaded to S3. By default this message will only display if the revision for `revisionData.revisionKey` of the deployment context has been activated.
+
+*Default:*
+
+```javascript
+if (context.revisionData.revisionKey && !context.revisionData.activatedRevisionKey) {
+  return "Deployed but did not activate revision " + context.revisionData.revisionKey + ". "
+       + "To activate, run: "
+       + "ember deploy:activate " + context.revisionData.revisionKey + " --environment=" + context.deployEnvironment + "\n";
+}
+```
+
+
+
 ### How do I activate a revision?
 
 A user can activate a revision by either:

--- a/index.js
+++ b/index.js
@@ -26,6 +26,15 @@ module.exports = {
         s3Client: function(context) {
           return context.s3Client; // if you want to provide your own S3 client to be used instead of one from aws-sdk
         },
+        didDeployMessage: function(context){
+          var revisionKey = context.revisionData && context.revisionData.revisionKey;
+          var activatedRevisionKey = context.revisionData && context.revisionData.activatedRevisionKey;
+          if (revisionKey && !activatedRevisionKey) {
+            return "Deployed but did not activate revision " + revisionKey + ". "
+                 + "To activate, run: "
+                 + "ember deploy:activate " + context.deployTarget + " --revision=" + revisionKey + "\n";
+          }
+        },
         allowOverwrite: false
       },
       requiredConfig: ['bucket', 'region'],
@@ -72,7 +81,20 @@ module.exports = {
         this.log('preparing to activate `' + revisionKey + '`', { verbose: true });
 
         var s3 = new S3({ plugin: this });
-        return s3.activate(options);
+        return s3.activate(options).then(function() {
+          return {
+            revisionData: {
+              activatedRevisionKey: revisionKey
+            }
+          }
+        });
+      },
+
+      didDeploy: function(/* context */){
+        var didDeployMessage = this.readConfig('didDeployMessage');
+        if (didDeployMessage) {
+          this.log(didDeployMessage);
+        }
       },
 
       fetchRevisions: function(context) {
@@ -91,6 +113,11 @@ module.exports = {
           .then(function(revisions) {
             context.revisions = revisions;
           });
+      },
+
+      _errorMessage: function(error) {
+        this.log(error, { color: 'red' });
+        return Promise.reject(error);
       },
     });
 


### PR DESCRIPTION
The ember-cli-deploy-redis plugin provides a "didDeployMessage" config option that allows it to report the revisionKey that got deployed, but not activated, along with a simple explanation about the next step required for activation.

This PR follows the same pattern for s3-index, and defaults to reporting the following after deploy:

Deployed but did not activate revision 268206c. To activate, run: ember deploy:activate production --revision=268206c

(this PR is a cleaned up version of https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index/pull/23)
