### PR TITLE
Fix #27: Conditionally add ContentEncoding:gzip header when index.html is gzipped

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ module.exports = {
         s3DeployClient: function(/* context */) {
           return new S3({ plugin: this });
         },
+        gzippedFiles: function(context) {
+          return context.gzippedFiles || [];
+        },
         allowOverwrite: false
       },
 
@@ -41,6 +44,7 @@ module.exports = {
         var revisionKey    = this.readConfig('revisionKey');
         var distDir        = this.readConfig('distDir');
         var filePattern    = this.readConfig('filePattern');
+        var gzippedFiles   = this.readConfig('gzippedFiles');
         var allowOverwrite = this.readConfig('allowOverwrite');
         var filePath    = path.join(distDir, filePattern);
 
@@ -51,6 +55,7 @@ module.exports = {
           filePattern: filePattern,
           filePath: filePath,
           revisionKey: revisionKey,
+          gzippedFilePaths: gzippedFiles,
           allowOverwrite: allowOverwrite
         };
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -36,13 +36,15 @@ module.exports = CoreObject.extend({
   },
 
   upload: function(options) {
-    var client         = this._client;
-    var plugin         = this._plugin;
-    var bucket         = options.bucket;
-    var acl            = options.acl;
-    var allowOverwrite = options.allowOverwrite;
-    var key            = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
-    var putObject      = Promise.denodeify(client.putObject.bind(client));
+    var client           = this._client;
+    var plugin           = this._plugin;
+    var bucket           = options.bucket;
+    var acl              = options.acl;
+    var allowOverwrite   = options.allowOverwrite;
+    var key              = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
+    var putObject        = Promise.denodeify(client.putObject.bind(client));
+    var gzippedFilePaths = options.gzippedFilePaths || [];
+    var isGzipped        = gzippedFilePaths.indexOf('index.html') !== -1;
 
     var params = {
       Bucket: bucket,
@@ -50,6 +52,10 @@ module.exports = CoreObject.extend({
       ACL: acl,
       ContentType: mime.lookup(options.filePath) || 'text/html',
       CacheControl: 'max-age=0, no-cache'
+    }
+
+    if (isGzipped) {
+      params.ContentEncoding = 'gzip';
     }
 
     return this.fetchRevisions(options)

--- a/tests/unit/lib/s3-nodetest.js
+++ b/tests/unit/lib/s3-nodetest.js
@@ -73,6 +73,7 @@ describe('s3', function() {
         bucket: bucket,
         prefix: '',
         acl: 'public-read',
+        gzippedFilePaths: [],
         filePattern: filePattern,
         revisionKey: revisionKey,
         filePath: 'tests/unit/fixtures/test.html',
@@ -134,6 +135,16 @@ describe('s3', function() {
         .then(function() {
           var expectedContentType = 'application/x-tar';
           assert.equal(s3Params.ContentType, expectedContentType, 'contentType is set to `application/x-tar');
+        });
+    });
+
+    it('sets the Content-Encoding header to gzip when the index file is gziped', function() {
+      options.gzippedFilePaths = ['index.html'];
+      var promise = subject.upload(options);
+
+      return assert.isFulfilled(promise)
+        .then(function() {
+          assert.equal(s3Params.ContentEncoding, 'gzip', 'contentEncoding is set to gzip');
         });
     });
 


### PR DESCRIPTION
Hey guys,

It fixes the issue #27 by adding the ContentEncoding header when the index.html file is gzipped. I borrowed the implementation from ember-cli-deploy-s3.

Let me know if it needs any enhancement =D
