### PR TITLE
Remove path.join on file upload key

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -44,14 +44,15 @@ module.exports = CoreObject.extend({
     var bucket           = options.bucket;
     var acl              = options.acl;
     var allowOverwrite   = options.allowOverwrite;
-    var key              = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
+    var key            = options.filePattern + ":" + options.revisionKey;
+    var revisionKey    = joinUriSegments(options.prefix, key);
     var putObject        = Promise.denodeify(client.putObject.bind(client));
     var gzippedFilePaths = options.gzippedFilePaths || [];
     var isGzipped        = gzippedFilePaths.indexOf('index.html') !== -1;
 
     var params = {
       Bucket: bucket,
-      Key: key,
+      Key: revisionKey,
       ACL: acl,
       ContentType: mime.lookup(options.filePath) || 'text/html',
       CacheControl: 'max-age=0, no-cache'
@@ -73,7 +74,7 @@ module.exports = CoreObject.extend({
       .then(function(fileContents) {
         params.Body = fileContents;
         return putObject(params).then(function() {
-          plugin.log('✔  ' + key, { verbose: true });
+          plugin.log('✔  ' + revisionKey, { verbose: true });
         });
     });
   },

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -5,7 +5,6 @@ var AWS        = require('aws-sdk');
 var CoreObject = require('core-object');
 var Promise    = require('ember-cli/lib/ext/promise');
 var fs         = require('fs');
-var path       = require('path');
 var readFile   = Promise.denodeify(fs.readFile);
 var mime       = require('mime-types');
 


### PR DESCRIPTION
When a prefix is specified on Windows, a file is created at the bucket with the full path as the name including a backslash (e.g. 'folder\index.html:foo')
