### PR TITLE
Add a deploy user to the metadata on s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ A flag to specify whether the revision should be overwritten if it already exist
 
 *Default:* `false`
 
+### deployer
+
+Name of the deployer
+ 
+*Default:* `git config --global user.name`
+
 ### s3Client
 
 The underlying S3 library used to upload the files to S3. This allows the user to use the default upload client provided by this plugin but switch out the underlying library that is used to actually send the files.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var path             = require('path');
 var Promise          = require('ember-cli/lib/ext/promise');
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 var S3               = require('./lib/s3');
+var syncExec         = require('sync-exec');
 
 module.exports = {
   name: 'ember-cli-deploy-s3-index',
@@ -29,7 +30,10 @@ module.exports = {
         s3DeployClient: function(/* context */) {
           return new S3({ plugin: this });
         },
-        allowOverwrite: false
+        allowOverwrite: false,
+        deployer: function(context) {
+          return context.deployer || syncExec('git config --global user.name').stdout;
+        }
       },
 
       requiredConfig: ['bucket', 'region'],
@@ -42,6 +46,7 @@ module.exports = {
         var distDir        = this.readConfig('distDir');
         var filePattern    = this.readConfig('filePattern');
         var allowOverwrite = this.readConfig('allowOverwrite');
+        var deployer       = this.readConfig('deployer');
         var filePath    = path.join(distDir, filePattern);
 
         var options = {
@@ -51,7 +56,8 @@ module.exports = {
           filePattern: filePattern,
           filePath: filePath,
           revisionKey: revisionKey,
-          allowOverwrite: allowOverwrite
+          allowOverwrite: allowOverwrite,
+          deployer: deployer
         };
 
         this.log('preparing to upload revision to S3 bucket `' + bucket + '`', { verbose: true });
@@ -65,6 +71,7 @@ module.exports = {
         var prefix      = this.readConfig('prefix');
         var acl         = this.readConfig('acl');
         var revisionKey = this.readConfig('revisionKey');
+        var deployer    = this.readConfig('deployer');
         var filePattern = this.readConfig('filePattern');
 
         var options = {
@@ -73,6 +80,7 @@ module.exports = {
           acl: acl,
           filePattern: filePattern,
           revisionKey: revisionKey,
+          deployer: deployer
         };
 
         this.log('preparing to activate `' + revisionKey + '`', { verbose: true });

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -41,6 +41,7 @@ module.exports = CoreObject.extend({
     var bucket         = options.bucket;
     var acl            = options.acl;
     var allowOverwrite = options.allowOverwrite;
+    var deployer       = options.deployer;
     var key            = path.join(options.prefix, options.filePattern + ":" + options.revisionKey);
     var putObject      = Promise.denodeify(client.putObject.bind(client));
 
@@ -49,8 +50,11 @@ module.exports = CoreObject.extend({
       Key: key,
       ACL: acl,
       ContentType: mime.lookup(options.filePath) || 'text/html',
-      CacheControl: 'max-age=0, no-cache'
-    }
+      CacheControl: 'max-age=0, no-cache',
+      Metadata: {
+        deployer: deployer
+      }
+    };
 
     return this.fetchRevisions(options)
       .then(function(revisions) {
@@ -74,8 +78,9 @@ module.exports = CoreObject.extend({
     var client      = this._client;
     var bucket      = options.bucket;
     var acl         = options.acl;
-    var prefix      = options.prefix
+    var prefix      = options.prefix;
     var filePattern = options.filePattern;
+    var deployer    = options.deployer;
     var key         = filePattern + ":" + options.revisionKey;
 
     var revisionKey = joinUriSegments(prefix, key);
@@ -88,6 +93,9 @@ module.exports = CoreObject.extend({
       CopySource: copySource,
       Key: indexKey,
       ACL: acl,
+      Metadata: {
+        deployer: deployer
+      }
     };
 
     return this.fetchRevisions(options).then(function(revisions) {
@@ -120,7 +128,12 @@ module.exports = CoreObject.extend({
       }).map(function(d) {
         var revision = d.Key.substr(revisionPrefix.length);
         var active = data.current && d.ETag === data.current.ETag;
-        return { revision: revision, timestamp: d.LastModified, active: active };
+        return {
+          revision: revision,
+          timestamp: d.LastModified,
+          active: active,
+          deployer: d.Metadata.deployer
+        };
       });
     });
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-deploy-plugin": "^0.2.1",
-    "mime-types": "^2.1.9"
+    "mime-types": "^2.1.9",
+    "sync-exec": "^0.6.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -48,6 +48,7 @@ describe('s3-index plugin', function() {
     it('fills the initialRevisions variable on context', function() {
       var plugin;
       var context;
+      var deployer = 'foo';
 
       plugin = subject.createDeployPlugin({
         name: 's3-index'
@@ -62,12 +63,14 @@ describe('s3-index plugin', function() {
             filePattern: 'index.html',
             bucket: 'my-bucket',
             region: 'my-region',
+            deployer: deployer,
             s3DeployClient: function(/* context */) {
               return {
                 fetchRevisions: function(/* keyPrefix, revisionKey */) {
                   return Promise.resolve([{
                     revision: 'a',
-                    active: false
+                    active: false,
+                    deployer: deployer
                   }]);
                 }
               };
@@ -83,7 +86,8 @@ describe('s3-index plugin', function() {
           assert.deepEqual(result, {
             initialRevisions: [{
               "active": false,
-              "revision": "a"
+              "revision": "a",
+              "deployer": deployer
             }]
           });
         });
@@ -94,6 +98,7 @@ describe('s3-index plugin', function() {
     it('fills the revisions variable on context', function() {
       var plugin;
       var context;
+      var deployer = 'foo';
 
       plugin = subject.createDeployPlugin({
         name: 's3-index'
@@ -109,12 +114,14 @@ describe('s3-index plugin', function() {
             filePattern: 'index.html',
             bucket: 'my-bucket',
             region: 'my-region',
+            deployer: deployer,
             s3DeployClient: function(/* context */) {
               return {
                 fetchRevisions: function(/* keyPrefix, revisionKey */) {
                   return Promise.resolve([{
                     revision: 'a',
-                    active: false
+                    active: false,
+                    deployer: deployer
                   }]);
                 }
               };
@@ -130,7 +137,8 @@ describe('s3-index plugin', function() {
           assert.deepEqual(result, {
               revisions: [{
                 "active": false,
-                "revision": "a"
+                "revision": "a",
+                "deployer": deployer
               }]
           });
         });


### PR DESCRIPTION
When the user uploads or activates a deploy it will also now set the deployer to what ever they have set in the config or default to `git config --global user.name`. 
The reasoning behind this is so that when using `ember deploy:list <env>` you will also see the user who deployed it as well.

See: https://github.com/ember-cli-deploy/ember-cli-deploy-display-revisions/blob/1e4a50e2bdbe4861169fa9830a0d4db098ba7f56/index.js#L75
- Also added sync-exec to get deployer name from git config
- Updated all tests with deployer metadata
