### PR TITLE
Implement `didActivate`-hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,25 @@ The client specified MUST implement functions called `getObject` and `putObject`
 
 *Default:* the default S3 library is `aws-sdk`
 
+### didActivate
+
+A function that can be use to do something after a revision was activated (i.e.
+you deployed a new default revision for all users). The function has access to
+the deployment context. Because of the way ember-cli-deploy reads configuration
+options you have to return the function that should be called from this hook.
+
+Example:
+
+```
+function() {
+  return function(/* deploymentContext */) {
+    return cdn.purge('index.html');
+  };
+}
+```
+
+*Default:* `function() {}`
+
 ### How do I activate a revision?
 
 A user can activate a revision by either:

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 var path             = require('path');
 var DeployPluginBase = require('ember-cli-deploy-plugin');
+var Promise          = require('ember-cli/lib/ext/promise');
 var S3               = require('./lib/s3');
 
 module.exports = {
@@ -81,6 +82,13 @@ module.exports = {
 
         var s3 = new this.S3({ plugin: this });
         return s3.activate(options);
+      },
+
+      didActivate: function(context) {
+        var didActivate = this.readConfig('didActivate') || function() {};
+
+        return Promise.resolve()
+          .then(didActivate.bind(this, context));
       },
 
       fetchRevisions: function(context) {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -98,6 +98,7 @@ describe('s3-index plugin', function() {
       assert.ok(plugin.configure);
       assert.ok(plugin.upload);
       assert.ok(plugin.activate);
+      assert.ok(plugin.didActivate);
       assert.ok(plugin.fetchRevisions);
       assert.ok(plugin.fetchInitialRevisions);
     });
@@ -164,6 +165,50 @@ describe('s3-index plugin', function() {
 
             assert.deepEqual(s3Options, expected);
           });
+      });
+    });
+
+    describe('#didActivate', function() {
+      it('calls a user defined function when `didActivate`-property is present in plugin configuration', function() {
+        var didActivateCalled = false;
+
+        context.config['s3-index'].didActivate = function() {
+          return function() {
+            didActivateCalled = true;
+          };
+        };
+
+        var promise = plugin.didActivate(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            assert.isTrue(didActivateCalled);
+          });
+      });
+
+      it('calls a user defined function that has access to the deployment context', function() {
+        var test = 'awesome';
+
+        context.awesome = 'sauce';
+
+        context.config['s3-index'].didActivate = function() {
+          return function(deployContext) {
+            test = test + deployContext.awesome;
+          };
+        };
+
+        var promise = plugin.didActivate(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            assert.equal(test, 'awesomesauce');
+          });
+      });
+
+      it('does not break when no didActivate property is present on plugin configuration', function() {
+        var promise = plugin.didActivate(context);
+
+        return assert.isFulfilled(promise);
       });
     });
 


### PR DESCRIPTION
This adds a configuration option for the didActivate-hook. Users can now return a function from the `didActivate`-configuration property that will get run by the plugin when the pipeline executes the didActivate hook.

This is useful when caching the index.html via a CDN that supports instant cache invalidation (e.g. Fastly, KeyCDN etc).
