### PR TITLE
Add appveyor for windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+# Fix line endings in Windows. (runs before repo cloning)
+init:
+  - git config --global core.autorclf true
+
+# Test against these versions of Node.js.
+environment:
+  matrix:
+    - nodejs_version: "0.12"
+    - nodejs_version: "4.2"
+    - nodejs_version: "5.0"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install -g bower
+  - npm install
+  - bower install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off


### PR DESCRIPTION
This makes sure we don't break deployments for users that are on windows. Obviously this is breaking right now but should be fixed as soon as https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index/pull/43 gets merged.
