### PR TITLE
Take `filePattern` into account when determining `isGzipped` status

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -44,7 +44,7 @@ module.exports = CoreObject.extend({
     var revisionKey    = joinUriSegments(options.prefix, key);
     var putObject        = Promise.denodeify(client.putObject.bind(client));
     var gzippedFilePaths = options.gzippedFilePaths || [];
-    var isGzipped        = gzippedFilePaths.indexOf('index.html') !== -1;
+    var isGzipped        = gzippedFilePaths.indexOf(options.filePattern) !== -1;
 
     var params = {
       Bucket: bucket,

--- a/tests/unit/lib/s3-nodetest.js
+++ b/tests/unit/lib/s3-nodetest.js
@@ -137,8 +137,8 @@ describe('s3', function() {
         });
     });
 
-    it('sets the Content-Encoding header to gzip when the index file is gziped', function() {
-      options.gzippedFilePaths = ['index.html'];
+    it('sets the Content-Encoding header to gzip when the index file is gzipped', function() {
+      options.gzippedFilePaths = [filePattern];
       var promise = subject.upload(options);
 
       return assert.isFulfilled(promise)


### PR DESCRIPTION
Hardcoding `index.html` limits the flexibility here; using `filePattern` sets
Content-Encoding header properly when file differs from `index.html`.
