### PR TITLE
Add support for recusively listing all revisions in a bucket

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -131,7 +131,7 @@ module.exports = CoreObject.extend({
       current: headObject(client, { Bucket: bucket, Key: indexKey }),
     })
     .then(function(data) {
-      return data.revisions.All.sort(function(a, b) {
+      return data.revisions.sort(function(a, b) {
         return new Date(b.LastModified) - new Date(a.LastModified);
       }).map(function(d) {
         var revision = d.Key.substr(revisionPrefix.length);
@@ -146,24 +146,21 @@ module.exports = CoreObject.extend({
     var listObjects    = RSVP.denodeify(client.listObjects.bind(client));
     var allRevisions   = [];
 
-    return new Promise(function(resolve, reject) {
-      function listObjectRecursively(options) {
-        listObjects(options).then(function(response) {
-          [].push.apply(allRevisions, response.Contents);
+    function listObjectRecursively(options) {
+      return listObjects(options).then(function(response) {
+        [].push.apply(allRevisions, response.Contents);
 
-          if (response.IsTruncated) {
-            var nextMarker = response.NextMarker || response.Contents[response.Contents.length - 1].Key;
-            options.Marker = nextMarker;
-            listObjectRecursively(options);
-          } else {
-            response.All = allRevisions;
-            resolve(response);
-          }
-        }).catch(reject);
-      }
+        if (response.IsTruncated) {
+          var nextMarker = response.Contents[response.Contents.length - 1].Key;
+          options.Marker = nextMarker;
+          return listObjectRecursively(options);
+        } else {
+          return allRevisions;
+        }
+      });
+    }
 
-      listObjectRecursively(options);
-    });
+    return listObjectRecursively(options);
 
   }
 });

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -125,14 +125,13 @@ module.exports = CoreObject.extend({
     var prefix         = options.prefix;
     var revisionPrefix = joinUriSegments(prefix, options.filePattern + ":");
     var indexKey       = joinUriSegments(prefix, options.filePattern);
-    var listObjects    = RSVP.denodeify(client.listObjects.bind(client));
 
     return RSVP.hash({
-      revisions: listObjects({ Bucket: bucket, Prefix: revisionPrefix }),
+      revisions: this.listAllObjects({ Bucket: bucket, Prefix: revisionPrefix }),
       current: headObject(client, { Bucket: bucket, Key: indexKey }),
     })
     .then(function(data) {
-      return data.revisions.Contents.sort(function(a, b) {
+      return data.revisions.All.sort(function(a, b) {
         return new Date(b.LastModified) - new Date(a.LastModified);
       }).map(function(d) {
         var revision = d.Key.substr(revisionPrefix.length);
@@ -141,4 +140,30 @@ module.exports = CoreObject.extend({
       });
     });
   },
+
+  listAllObjects: function(options) {
+    var client         = this._client;
+    var listObjects    = RSVP.denodeify(client.listObjects.bind(client));
+    var allRevisions   = [];
+
+    return new Promise(function(resolve, reject) {
+      function listObjectRecursively(options) {
+        listObjects(options).then(function(response) {
+          [].push.apply(allRevisions, response.Contents);
+
+          if (response.IsTruncated) {
+            var nextMarker = response.NextMarker || response.Contents[response.Contents.length - 1].Key;
+            options.Marker = nextMarker;
+            listObjectRecursively(options);
+          } else {
+            response.All = allRevisions;
+            resolve(response);
+          }
+        }).catch(reject);
+      }
+
+      listObjectRecursively(options);
+    });
+
+  }
 });


### PR DESCRIPTION
`s3.listObjects` has a `MaxKeys` parameter which defaults to `1000`.
Unfortunately this also appears to be the highest value that you can
set it to. When you have more than 1000 items matching the prefix in
your bucket then some items were not being returned.

Since there is no sorting options this could result in the plugin
declaring "REVISION NOT FOUND!" when passed a value revision id.

This commit makes sure that we page through the results from the call
to `s3.listObjects` so that all results are loaded.
