### PR TITLE
Support AWS credential profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ The AWS secret for the user that has the ability to upload to the `bucket`. This
 
 *Default:* `undefined`
 
+### profile
+
+The AWS profile as definied in ~/.aws/credentials. If this is left undefined, the normal [AWS SDK credential resolution][7] will take place.
+
+*Default:* `undefined`
+
 ### bucket (`required`)
 
 The AWS bucket that the files will be uploaded to.

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -29,10 +29,10 @@ module.exports = CoreObject.extend({
     this._super();
     var plugin = options.plugin;
     var config = plugin.pluginConfig;
+    var profile = config.profile;
 
     this._plugin = plugin;
 
-    const profile = this._plugin.readConfig('profile');
     if (profile && !this._plugin.readConfig('s3Client')) {
       this._plugin.log('Using AWS profile from config', { verbose: true });
       AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: profile });

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -29,7 +29,7 @@ module.exports = CoreObject.extend({
     this._super();
     var plugin = options.plugin;
     var config = plugin.pluginConfig;
-    var profile = config.profile;
+    var profile = plugin.readConfig('profile');
 
     this._plugin = plugin;
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -29,8 +29,15 @@ module.exports = CoreObject.extend({
     this._super();
     var plugin = options.plugin;
     var config = plugin.pluginConfig;
+    var profile = plugin.readConfig('profile');
 
     this._plugin = plugin;
+
+    if (profile && !this._plugin.readConfig('s3Client')) {
+      this._plugin.log('Using AWS profile from config', { verbose: true });
+      AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: profile });
+    }
+
     this._client = plugin.readConfig('s3Client') || new AWS.S3(config);
   },
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -31,6 +31,13 @@ module.exports = CoreObject.extend({
     var config = plugin.pluginConfig;
 
     this._plugin = plugin;
+
+    const profile = this._plugin.readConfig('profile');
+    if (profile && !this._plugin.readConfig('s3Client')) {
+      this._plugin.log('Using AWS profile from config', { verbose: true });
+      AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: profile });
+    }
+
     this._client = plugin.readConfig('s3Client') || new AWS.S3(config);
   },
 


### PR DESCRIPTION
## What Changed & Why
Added support for AWS credential profiles as seen in `ember-cli-deploy-s3`.

## Related issues
ember-cli-deploy/ember-cli-deploy-s3#95

## PR Checklist
- [ ] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)
