### PR TITLE
Switch default cacheControl to 'private, no-cache'

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The ACL to apply to the objects.
 
 Sets the `Cache-Control` header on uploaded files.
 
-*Default:* `'max-age=0, no-cache'`
+*Default:* `'private, no-store'`
 
 ### distDir
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
         filePattern: 'index.html',
         prefix: '',
         acl: 'public-read',
-        cacheControl: 'max-age=0, no-cache',
+        cacheControl: 'private, no-store',
         distDir: function(context) {
           return context.distDir;
         },

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -20,7 +20,7 @@ describe('s3-index plugin', function() {
   var DEFAULT_PREFIX          = '';
   var DEFAULT_FILE_PATTERN    = 'index.html';
   var DEFAULT_ACL             = 'public-read';
-  var DEFAULT_CACHE_CONTROL   = 'max-age=0, no-cache';
+  var DEFAULT_CACHE_CONTROL   = 'private, no-store';
 
   function s3Stub(returnValue) {
     return function(options) {

--- a/tests/unit/lib/s3-test.js
+++ b/tests/unit/lib/s3-test.js
@@ -72,7 +72,7 @@ describe('s3', function() {
         bucket: bucket,
         prefix: '',
         acl: 'public-read',
-        cacheControl: 'max-age=0, no-cache',
+        cacheControl: 'private, no-store',
         gzippedFilePaths: [],
         filePattern: filePattern,
         revisionKey: revisionKey,
@@ -121,7 +121,7 @@ describe('s3', function() {
           assert.equal(s3Params.Key, expectedKey, 'Key passed correctly');
           assert.equal(s3Params.ACL, defaultACL, 'ACL defaults to `public-read`');
           assert.equal(s3Params.ContentType, 'text/html', 'contentType is set to `text/html`');
-          assert.equal(s3Params.CacheControl, 'max-age=0, no-cache', 'cacheControl set correctly');
+          assert.equal(s3Params.CacheControl, 'private, no-store', 'cacheControl set correctly');
         });
     });
 


### PR DESCRIPTION
## What Changed & Why
This config is more powerful than 'max-cache: 0, no-cache', not to
cache the index.html file.

According to MDN:
- no-store: The cache should not store anything about the client request
or server response.
- no-cache: Forces caches to submit the request to the origin server
for validation before releasing a cached copy.
- private: Indicates that the response is intended for a single user and
must not be stored by a shared cache. A private cache may store the
response.

## Related issues
https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index/issues/78

## PR Checklist
- [x ] Add tests
- [ x] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
@LevelbossMike 
