### PR TITLE
Add brotli support

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ module.exports = {
         gzippedFiles: function(context) {
           return context.gzippedFiles || [];
         },
+        brotliCompressedFiles: function(context) {
+          return context.brotliCompressedFiles || [];
+        },
         allowOverwrite: false
       },
 
@@ -44,6 +47,7 @@ module.exports = {
         var distDir               = this.readConfig('distDir');
         var filePattern           = this.readConfig('filePattern');
         var gzippedFiles          = this.readConfig('gzippedFiles');
+        var brotliCompressedFiles = this.readConfig('brotliCompressedFiles');
         var allowOverwrite        = this.readConfig('allowOverwrite');
         var serverSideEncryption  = this.readConfig('serverSideEncryption');
         var filePath              = joinUriSegments(distDir, filePattern);
@@ -57,6 +61,7 @@ module.exports = {
           filePath: filePath,
           revisionKey: revisionKey,
           gzippedFilePaths: gzippedFiles,
+          brotliCompressedFilePaths: brotliCompressedFiles,
           allowOverwrite: allowOverwrite
         };
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -48,18 +48,20 @@ module.exports = CoreObject.extend({
   },
 
   upload: function(options) {
-    var client                = this._client;
-    var plugin                = this._plugin;
-    var bucket                = options.bucket;
-    var acl                   = options.acl;
-    var cacheControl          = options.cacheControl;
-    var allowOverwrite        = options.allowOverwrite;
-    var key                   = options.filePattern + ":" + options.revisionKey;
-    var revisionKey           = joinUriSegments(options.prefix, key);
-    var putObject             = RSVP.denodeify(client.putObject.bind(client));
-    var gzippedFilePaths      = options.gzippedFilePaths || [];
-    var isGzipped             = gzippedFilePaths.indexOf(options.filePattern) !== -1;
-    var serverSideEncryption  = options.serverSideEncryption;
+    var client                    = this._client;
+    var plugin                    = this._plugin;
+    var bucket                    = options.bucket;
+    var acl                       = options.acl;
+    var cacheControl              = options.cacheControl;
+    var allowOverwrite            = options.allowOverwrite;
+    var key                       = options.filePattern + ":" + options.revisionKey;
+    var revisionKey               = joinUriSegments(options.prefix, key);
+    var putObject                 = RSVP.denodeify(client.putObject.bind(client));
+    var gzippedFilePaths          = options.gzippedFilePaths || [];
+    var brotliCompressedFilePaths = options.brotliCompressedFilePaths || [];
+    var isGzipped                 = gzippedFilePaths.indexOf(options.filePattern) !== -1;
+    var isBrotliCompressed        = brotliCompressedFilePaths.indexOf(options.filePattern) !== -1;
+    var serverSideEncryption      = options.serverSideEncryption;
 
     var params = {
       Bucket: bucket,
@@ -75,6 +77,10 @@ module.exports = CoreObject.extend({
 
     if (isGzipped) {
       params.ContentEncoding = 'gzip';
+    }
+
+    if (isBrotliCompressed) {
+      params.ContentEncoding = 'br';
     }
 
     return this.fetchRevisions(options)

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -117,6 +117,7 @@ describe('s3-index plugin', function() {
               filePattern: DEFAULT_FILE_PATTERN,
               filePath: DIST_DIR+'/'+DEFAULT_FILE_PATTERN,
               gzippedFilePaths: [],
+              brotliCompressedFilePaths: [],
               revisionKey: REVISION_KEY,
               allowOverwrite: false
             };
@@ -160,6 +161,7 @@ describe('s3-index plugin', function() {
               filePattern: DEFAULT_FILE_PATTERN,
               filePath: DIST_DIR+'/'+DEFAULT_FILE_PATTERN,
               gzippedFilePaths: [],
+              brotliCompressedFilePaths: [],
               revisionKey: REVISION_KEY,
               allowOverwrite: false
             };
@@ -183,6 +185,31 @@ describe('s3-index plugin', function() {
               filePattern: DEFAULT_FILE_PATTERN,
               filePath: DIST_DIR+'/'+DEFAULT_FILE_PATTERN,
               gzippedFilePaths: ['index.html'],
+              brotliCompressedFilePaths: [],
+              revisionKey: REVISION_KEY,
+              allowOverwrite: false
+            };
+
+            assert.deepEqual(s3Options, expected);
+          });
+      });
+
+      it('passes brotliCompressedFilePaths to S3 based on the `context.brotliCompressedFiles` that ember-cli-deploy-compress provides', function() {
+        context.brotliCompressedFiles = ['index.html'];
+
+        var promise = plugin.upload(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            var expected = {
+              acl: DEFAULT_ACL,
+              cacheControl: DEFAULT_CACHE_CONTROL,
+              bucket: BUCKET,
+              prefix: DEFAULT_PREFIX,
+              filePattern: DEFAULT_FILE_PATTERN,
+              filePath: DIST_DIR+'/'+DEFAULT_FILE_PATTERN,
+              gzippedFilePaths: [],
+              brotliCompressedFilePaths: ['index.html'],
               revisionKey: REVISION_KEY,
               allowOverwrite: false
             };

--- a/tests/unit/lib/s3-test.js
+++ b/tests/unit/lib/s3-test.js
@@ -167,6 +167,16 @@ describe('s3', function() {
         });
     });
 
+    it('sets the Content-Encoding header to br when the index file is brotli compressed', function() {
+      options.brotliCompressedFilePaths = [filePattern];
+      var promise = subject.upload(options);
+
+      return assert.isFulfilled(promise)
+        .then(function() {
+          assert.equal(s3Params.ContentEncoding, 'br', 'contentEncoding is set to br');
+        });
+    });
+
     it('allows `prefix` option to be passed to customize upload-path', function() {
       var prefix = 'my-app';
 


### PR DESCRIPTION
## What Changed & Why
Add support for brotli-compressed index.html, that `ember-cli-deploy-brotli` or `ember-cli-deploy-compress` is able to provide.

## Related issues
Related to `ember-cli-deploy-s3` PR: https://github.com/ember-cli-deploy/ember-cli-deploy-s3/pull/104

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
@cibernox
