### PR TITLE
Add an option to disable URL encoding source

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ The Server-side encryption algorithm used when storing this object in S3 (e.g., 
   - "AES256"
   - "aws:kms"
 
+### urlEncodeSourceObject
+
+Controls if the `x-amz-copy-source` header is going to be be URL encoded.
+There is a known issue with DigitalOcean Spaces and older versions of CEPH
+that don't accept URL encoded copy sources.
+
+If you are using DigitalOcean spaces you need to set this setting to `false`.
+
+*Default:* `true`
+
 ### How do I activate a revision?
 
 A user can activate a revision by either:

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
         prefix: '',
         acl: 'public-read',
         cacheControl: 'max-age=0, no-cache',
+        urlEncodeSourceObject: true,
         distDir: function(context) {
           return context.distDir;
         },
@@ -50,6 +51,7 @@ module.exports = {
         var brotliCompressedFiles = this.readConfig('brotliCompressedFiles');
         var allowOverwrite        = this.readConfig('allowOverwrite');
         var serverSideEncryption  = this.readConfig('serverSideEncryption');
+        var urlEncodeSourceObject = this.readConfig('urlEncodeSourceObject');
         var filePath              = joinUriSegments(distDir, filePattern);
 
         var options = {
@@ -62,7 +64,8 @@ module.exports = {
           revisionKey: revisionKey,
           gzippedFilePaths: gzippedFiles,
           brotliCompressedFilePaths: brotliCompressedFiles,
-          allowOverwrite: allowOverwrite
+          allowOverwrite: allowOverwrite,
+          urlEncodeSourceObject: urlEncodeSourceObject
         };
 
         if (serverSideEncryption) {

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -108,19 +108,24 @@ module.exports = CoreObject.extend({
     var prefix                = options.prefix;
     var filePattern           = options.filePattern;
     var key                   = filePattern + ":" + options.revisionKey;
-    var serverSideEncryption  =  options.serverSideEncryption;
+    var serverSideEncryption  = options.serverSideEncryption;
+    var urlEncodeSourceObject = options.urlEncodeSourceObject;
 
     var revisionKey           = joinUriSegments(prefix, key);
     var indexKey              = joinUriSegments(prefix, filePattern);
-    var copySource            = encodeURIComponent([bucket, revisionKey].join('/'));
     var copyObject            = RSVP.denodeify(client.copyObject.bind(client));
 
     var params = {
       Bucket: bucket,
-      CopySource: copySource,
       Key: indexKey,
       ACL: acl,
     };
+
+    if (urlEncodeSourceObject) {
+        params.CopySource = encodeURIComponent([bucket, revisionKey].join('/'));
+    } else {
+        params.CopySource = `${bucket}/${revisionKey}`
+    }
 
     if (serverSideEncryption) {
       params.ServerSideEncryption = serverSideEncryption;

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -119,7 +119,8 @@ describe('s3-index plugin', function() {
               gzippedFilePaths: [],
               brotliCompressedFilePaths: [],
               revisionKey: REVISION_KEY,
-              allowOverwrite: false
+              allowOverwrite: false,
+              urlEncodeSourceObject: true
             };
 
             assert.deepEqual(s3Options, expected);
@@ -163,7 +164,8 @@ describe('s3-index plugin', function() {
               gzippedFilePaths: [],
               brotliCompressedFilePaths: [],
               revisionKey: REVISION_KEY,
-              allowOverwrite: false
+              allowOverwrite: false,
+              urlEncodeSourceObject: true
             };
 
             assert.deepEqual(s3Options, expected);
@@ -187,7 +189,8 @@ describe('s3-index plugin', function() {
               gzippedFilePaths: ['index.html'],
               brotliCompressedFilePaths: [],
               revisionKey: REVISION_KEY,
-              allowOverwrite: false
+              allowOverwrite: false,
+              urlEncodeSourceObject: true
             };
 
             assert.deepEqual(s3Options, expected);
@@ -211,7 +214,8 @@ describe('s3-index plugin', function() {
               gzippedFilePaths: [],
               brotliCompressedFilePaths: ['index.html'],
               revisionKey: REVISION_KEY,
-              allowOverwrite: false
+              allowOverwrite: false,
+              urlEncodeSourceObject: true
             };
 
             assert.deepEqual(s3Options, expected);


### PR DESCRIPTION
## What Changed & Why

A bug in CEPH which is used as a drop in S3 replacement by some providers such as DigitalOcean, don't allow URL encoding of the `x-amz-copy-source` header.

https://tracker.ceph.com/issues/22121

The issue has been fixed but DigitalOcean still seems to have this issue and returns an "InvalidArgument" error when the `x-amz-copy-source` is URL encoded.

This adds an option (`urlEncodeSourceObject`) to disable URL encoding of the `x-amz-copy-source` header.

## Related issues
This fixes https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index/issues/95

## PR Checklist
- [x] Add tests
- [x] Add documentation
