### PR TITLE
fix: pass urlEncodeSourceObject option to S3-abstraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ module.exports = {
         var revisionKey           = this.readConfig('revisionKey');
         var filePattern           = this.readConfig('filePattern');
         var serverSideEncryption  = this.readConfig('serverSideEncryption');
+        var urlEncodeSourceObject = this.readConfig('urlEncodeSourceObject');
 
         var options = {
           bucket: bucket,
@@ -92,6 +93,7 @@ module.exports = {
           acl: acl,
           filePattern: filePattern,
           revisionKey: revisionKey,
+          urlEncodeSourceObject: urlEncodeSourceObject,
         };
 
         if (serverSideEncryption) {

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -236,7 +236,8 @@ describe('s3-index plugin', function() {
               bucket: BUCKET,
               prefix: DEFAULT_PREFIX,
               filePattern: DEFAULT_FILE_PATTERN,
-              revisionKey: '1234'
+              revisionKey: '1234',
+              urlEncodeSourceObject: true,
             };
 
             assert.deepEqual(s3Options, expected);


### PR DESCRIPTION
## What Changed & Why

### What

Fix a "breaking" issue in v1.3.0, by sending `urlEncodeSourceObject` option to `activate` hook in S3-abstraction

### Why

The new option `urlEncodeSourceObject` added in v1.3.0 via https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index/commit/468671eeef16eb8e98e06ee5e533f8299c27e2c8 was not sent to the `lib/s3.js` `activate` method

See code [here](https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index/commit/468671eeef16eb8e98e06ee5e533f8299c27e2c8#diff-447cacdaa835d04dbe2eb2e568567d41aac4128ed4d0390112904965dff7a106R124)

By default this option is set to `true` (and when set to `true` it use `encodeURIComponent([bucket, revisionKey].join('/'))`)

But as this option is not send to `activate` hook, deployment is failing because it will now always use `${bucket}/${revisionKey}` (instead of `encodeURIComponent([bucket, revisionKey].join('/'))`), which means that S3 is trying to activate an incorrect key. Following error is thrown by `aws-sdk`
```
NoSuchKey: The specified key does not exist.
```


## Related issues

None created

## PR Checklist
- [x] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People

Mention people who would be interested in the changeset (if any)
