### PR TITLE
Optimise activation speed

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -83,10 +83,9 @@ module.exports = CoreObject.extend({
       params.ContentEncoding = 'br';
     }
 
-    return this.fetchRevisions(options)
-      .then(function(revisions) {
-        var found = revisions.map(function(element) { return element.revision; }).indexOf(options.revisionKey);
-        if (found >= 0 && !allowOverwrite) {
+    return this.findRevision(options)
+      .then(function(found) {
+        if (found !== undefined && !allowOverwrite) {
           return RSVP.reject("REVISION ALREADY UPLOADED! (set `allowOverwrite: true` if you want to support overwriting revisions)");
         }
         return RSVP.resolve();

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -131,9 +131,8 @@ module.exports = CoreObject.extend({
       params.ServerSideEncryption = serverSideEncryption;
     }
 
-    return this.fetchRevisions(options).then(function(revisions) {
-      var found = revisions.map(function(element) { return element.revision; }).indexOf(options.revisionKey);
-      if (found >= 0) {
+    return this.findRevision(options).then(function(found) {
+      if (found !== undefined) {
         return copyObject(params).then(function() {
           plugin.log('✔  ' + revisionKey + " => " + indexKey);
         });
@@ -141,6 +140,16 @@ module.exports = CoreObject.extend({
         return RSVP.reject("REVISION NOT FOUND!"); // see how we should handle a pipeline failure
       }
     });
+  },
+
+  findRevision: function(options) {
+    var client         = this._client;
+    var listObjects    = RSVP.denodeify(client.listObjects.bind(client));
+    var bucket         = options.bucket;
+    var prefix         = options.prefix;
+    var revisionPrefix = joinUriSegments(prefix, options.filePattern + ":" + options.revisionKey);
+
+    return listObjects({ Bucket: bucket, Prefix: revisionPrefix }).then((response) => response.Contents[0]);
   },
 
   fetchRevisions: function(options) {

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -149,7 +149,8 @@ module.exports = CoreObject.extend({
     var prefix         = options.prefix;
     var revisionPrefix = joinUriSegments(prefix, options.filePattern + ":" + options.revisionKey);
 
-    return listObjects({ Bucket: bucket, Prefix: revisionPrefix }).then((response) => response.Contents[0]);
+    return listObjects({ Bucket: bucket, Prefix: revisionPrefix })
+      .then((response) => response.Contents.find((element) => element.Key === revisionPrefix));
   },
 
   fetchRevisions: function(options) {


### PR DESCRIPTION
## What Changed & Why
I noticed that the activation step of our deployments was getting pretty slow. When digging into it I figured out that it's because we have 60,000+ revisions for each app deployed and the activation process uses S3's `ListObjects` no fewer than 3 times to get that list of revisions. This gets to be pretty slooooow!

This PR includes the first simple changes which don't change existing functionality. In a couple of places the list of all revisions were being loaded just to figure out if the passed revision was valid. Instead we can pass a `prefix` to `ListObjects` which is the _entire_ key we are searching for. Rather than downloading them _all_ and searching them clientside we just try to download the *one* we want.

For one of our apps with a fair amount of history (just over 60,000 deployments) this takes the activation down from 835s to 590s (a 30% reduction on my computer and internet connection - probably a bit better from CI!).

There are still two places in the flow where we download the entire list of deployed items but the fix there is less simple...

## Related issues
I discuss potential follow up tasks in #120 

## PR Checklist
- [x] Add tests (I didn't add any tests but I verified that tests exist for the specific functionality I tested and that they still pass)
- [x] Add documentation (I'm not sure this needs to be called out in documentation?)
- [x] Prefix documentation-only commits with [DOC] (N/A if there is no docs?)

## People
All maintainers ;)
