### PR TITLE
Really optimise activation speed

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,11 +116,35 @@ module.exports = {
       },
 
       fetchInitialRevisions: function(context) {
+
+        if (this.readConfig('fetchOnlyRelevantRevisions')) {
+          this.log('fetchInitialRevisions - fetching only enough revisions to find the active revision', { verbose: true });
+          return this._fetchActiveRevision();
+        }
+
         return this._list(context)
           .then(function(revisions) {
             return {
               initialRevisions: revisions
             };
+          });
+      },
+
+      _fetchActiveRevision: function() {
+        var bucket      = this.readConfig('bucket');
+        var prefix      = this.readConfig('prefix');
+        var filePattern = this.readConfig('filePattern');
+
+        var options = {
+          bucket: bucket,
+          prefix: prefix,
+          filePattern: filePattern,
+        };
+
+        var s3 = new this.S3({ plugin: this });
+        return s3.getActiveRevision(options)
+          .then((activeRevision) => {
+            return { initialRevisions: [activeRevision] };
           });
       },
 

--- a/index.js
+++ b/index.js
@@ -107,6 +107,13 @@ module.exports = {
       },
 
       fetchRevisions: function(context) {
+        if (this.readConfig('disableFetchRevisions')) {
+          this.log('fetchRevisions - not fetching any revisions', { verbose: true });
+          return {
+            activations: []
+          };
+        }
+
         return this._list(context)
           .then(function(revisions) {
             return {

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -174,7 +174,7 @@ module.exports = CoreObject.extend({
     });
   },
 
-  listAllObjects: function(options) {
+  listAllObjects: function(options, until) {
     var client         = this._client;
     var listObjects    = RSVP.denodeify(client.listObjects.bind(client));
     var allRevisions   = [];
@@ -183,13 +183,14 @@ module.exports = CoreObject.extend({
       return listObjects(options).then(function(response) {
         [].push.apply(allRevisions, response.Contents);
 
-        if (response.IsTruncated) {
-          var nextMarker = response.Contents[response.Contents.length - 1].Key;
-          options.Marker = nextMarker;
-          return listObjectRecursively(options);
-        } else {
+        var isComplete = !response.IsTruncated || (until && response.Contents.some(until));
+
+        if (isComplete) {
           return allRevisions;
         }
+        var nextMarker = response.Contents[response.Contents.length - 1].Key;
+        options.Marker = nextMarker;
+        return listObjectRecursively(options);
       });
     }
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -160,7 +160,12 @@ module.exports = CoreObject.extend({
     var indexKey       = joinUriSegments(prefix, options.filePattern);
 
     return headObject(client, { Bucket: bucket, Key: indexKey })
-      .then((current) => this.listAllObjects(
+      .then((current) => {
+        if (current === undefined) {
+          return;
+        }
+
+        return this.listAllObjects(
           { Bucket: bucket, Prefix: revisionPrefix }, 
           (element) => element.ETag === current.ETag
         )
@@ -173,7 +178,7 @@ module.exports = CoreObject.extend({
           var revision = activeRevision.Key.substr(revisionPrefix.length);
           return { active: true, revision, timestamp: activeRevision.LastModified };
         })
-      );
+      });
 
   },
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -152,6 +152,31 @@ module.exports = CoreObject.extend({
       .then((response) => response.Contents.find((element) => element.Key === revisionPrefix));
   },
 
+  getActiveRevision(options) {
+    var client         = this._client;
+    var bucket         = options.bucket;
+    var prefix         = options.prefix;
+    var revisionPrefix = joinUriSegments(prefix, options.filePattern + ":");
+    var indexKey       = joinUriSegments(prefix, options.filePattern);
+
+    return headObject(client, { Bucket: bucket, Key: indexKey })
+      .then((current) => this.listAllObjects(
+          { Bucket: bucket, Prefix: revisionPrefix }, 
+          (element) => element.ETag === current.ETag
+        )
+        .then((elements) => {
+          let activeRevision = elements.find((element) => element.ETag === current.ETag);
+          if (!activeRevision) {
+            return;
+          }
+          
+          var revision = activeRevision.Key.substr(revisionPrefix.length);
+          return { active: true, revision, timestamp: activeRevision.LastModified };
+        })
+      );
+
+  },
+
   fetchRevisions: function(options) {
     var client         = this._client;
     var bucket         = options.bucket;


### PR DESCRIPTION
## What Changed & Why
Building on #119 and trying to fix #120 this PR introduces a couple of new config options for this plugin:

 * `fetchOnlyRelevantRevisions` - If set then this changes the behaviour of `fetchInitialRevisions` so that it only continues hitting `ListObjects` until it has found the currently active revision. This is done on the assumption that the main use-case for `fetchInitialRevisions` is to be able to build other plugins which record the previous and current version when you activate
 * `disableFetchRevisions` - if set then this short-circuits `fetchRevisions` within this plugin. This is because `fetchRevisions` [is called](http://ember-cli-deploy.com/docs/v1.0.x/pipeline-hooks/) after `activate` and I'm not sure what the list of revisions is needed for (see related conversation in #120). Not loading it can speed things up considerably.

If I use this branch and set both flags for one of our apps and environments (which has ~60,000 deployments in S3) then the activate command completes in 139 seconds on my computer (down from 590s on #119 and 835s prior to that - an overall improvement of over 80%). 

The way to get quicker than this is to track the currently active version more explicitly somewhere so we don't have to loop over S3 at all - at that point it feels like maybe it is a different plugin though...

## Related issues
#120 

## PR Checklist

I'm happy to do the below stuff but thought it was worth submitting this for discussion at this point... How do people feel about the changes? Do they make sense? Would they be useful to anyone other than us? Any better names for the config options?

- [ ] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
All maintainers? :)
