### PR TITLE
fix: Optimise upload when `allowOverwrite` is true

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -62,6 +62,7 @@ module.exports = CoreObject.extend({
     var isGzipped                 = gzippedFilePaths.indexOf(options.filePattern) !== -1;
     var isBrotliCompressed        = brotliCompressedFilePaths.indexOf(options.filePattern) !== -1;
     var serverSideEncryption      = options.serverSideEncryption;
+    var checkForOverwrite         = RSVP.resolve();
 
     var params = {
       Bucket: bucket,
@@ -83,13 +84,17 @@ module.exports = CoreObject.extend({
       params.ContentEncoding = 'br';
     }
 
-    return this.findRevision(options)
-      .then(function(found) {
-        if (found !== undefined && !allowOverwrite) {
-          return RSVP.reject("REVISION ALREADY UPLOADED! (set `allowOverwrite: true` if you want to support overwriting revisions)");
-        }
-        return RSVP.resolve();
-      })
+    if (!allowOverwrite) {
+      checkForOverwrite = this.findRevision(options)
+        .then(function(found) {
+          if (found !== undefined) {
+            return RSVP.reject("REVISION ALREADY UPLOADED! (set `allowOverwrite: true` if you want to support overwriting revisions)");
+          }
+          return RSVP.resolve();
+        })
+    }
+
+    return checkForOverwrite
       .then(readFile.bind(this, options.filePath))
       .then(function(fileContents) {
         params.Body = fileContents;


### PR DESCRIPTION
There is no need to try and figure out if a revision has already been deployed
if we are going to overwrite it anyway. Let's save ourselves the network request!

## What Changed & Why
Just a simple optimisation as described above. It's not going to make much difference because
since #119 it's been a single request to find if the revision exists. But it is still a little bit of work
that doesn't need to be done...

## Related issues
#119 #121 

## PR Checklist
- [x] Add tests (There is already test coverage for both paths here and it still passes)
- [x] Add documentation (N/A - this isn't a user-facing change)
- [x] Prefix documentation-only commits with [DOC] (N/A)

## People
All maintainers :)
