### PR TITLE
Add support for didDeployMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ If you are using DigitalOcean spaces you need to set this setting to `false`.
 
 *Default:* `true`
 
+### didDeployMessage
+
+A message that will be displayed after the index file has been successfully uploaded to S3. By default this message will only display if the revision for `revisionData.revisionKey` of the deployment context has been activated.
+
+*Default:*
+
+```javascript
+if (context.revisionData.revisionKey && !context.revisionData.activatedRevisionKey) {
+  return "Deployed but did not activate revision " + context.revisionData.revisionKey + ". "
+       + "To activate, run: "
+       + "ember deploy:activate " + context.revisionData.revisionKey + " --environment=" + context.deployEnvironment + "\n";
+}
+```
+
+
+
 ### How do I activate a revision?
 
 A user can activate a revision by either:

--- a/index.js
+++ b/index.js
@@ -34,6 +34,15 @@ module.exports = {
         brotliCompressedFiles: function(context) {
           return context.brotliCompressedFiles || [];
         },
+        didDeployMessage: function(context){
+          var revisionKey = context.revisionData && context.revisionData.revisionKey;
+          var activatedRevisionKey = context.revisionData && context.revisionData.activatedRevisionKey;
+          if (revisionKey && !activatedRevisionKey) {
+            return "Deployed but did not activate revision " + revisionKey + ". "
+                 + "To activate, run: "
+                 + "ember deploy:activate " + context.deployTarget + " --revision=" + revisionKey + "\n";
+          }
+        },
         allowOverwrite: false
       },
 
@@ -103,7 +112,20 @@ module.exports = {
         this.log('preparing to activate `' + revisionKey + '`', { verbose: true });
 
         var s3 = new this.S3({ plugin: this });
-        return s3.activate(options);
+        return s3.activate(options).then(function() {
+          return {
+            revisionData: {
+              activatedRevisionKey: revisionKey
+            }
+          }
+        });
+      },
+
+      didDeploy: function(/* context */){
+        var didDeployMessage = this.readConfig('didDeployMessage');
+        if (didDeployMessage) {
+          this.log(didDeployMessage);
+        }
       },
 
       fetchRevisions: function(context) {

--- a/index.js
+++ b/index.js
@@ -112,7 +112,9 @@ module.exports = {
         this.log('preparing to activate `' + revisionKey + '`', { verbose: true });
 
         var s3 = new this.S3({ plugin: this });
-        return s3.activate(options).then(function() {
+        return s3.activate(options).then(() => {
+          this.log(`✔ Activated revision \`${revisionKey}\``, {});
+
           return {
             revisionData: {
               activatedRevisionKey: revisionKey

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -61,6 +61,7 @@ describe('s3-index plugin', function() {
     });
 
     context = {
+      deployTarget: "qa",
       ui: mockUi,
 
       project: stubProject,
@@ -262,6 +263,15 @@ describe('s3-index plugin', function() {
             assert.equal(Object.prototype.hasOwnProperty.call(s3Options, 'serverSideEncryption'), false, 'serverSideEncryption filtered correctly');
           });
       });
+
+      it('displays activation message when revision is activated', function() {
+        var promise = plugin.activate(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            assert.match(mockUi.messages.join("\n"),  new RegExp(`✔ Activated revision \`${REVISION_KEY}\``));
+          });
+      })
     });
 
     describe('#fetchInitialRevisions', function() {
@@ -313,6 +323,22 @@ describe('s3-index plugin', function() {
 
             assert.deepEqual(s3Options, expected);
           });
+      });
+    });
+
+    describe('#didDeploy', function() {
+      it("prints default message about lack of activation when revision has not been activated", function() {
+        plugin.upload = function() {};
+        plugin.activate = function() {};
+        plugin.beforeHook(context);
+        plugin.configure(context);
+        plugin.beforeHook(context);
+        plugin.didDeploy(context);
+
+        let message = mockUi.messages.join("\n")
+        assert.match(message, new RegExp(`Deployed but did not activate revision ${REVISION_KEY}`));
+        assert.match(message, /To activate, run/);
+        assert.match(message, new RegExp(`ember deploy:activate qa --revision=${REVISION_KEY}`));
       });
     });
   });


### PR DESCRIPTION
## What Changed & Why
It wasn't clear how #40 and #23 were closed without getting merged, so I took that content and rebased it to make the third-incarnation of this change attempt. 😛 

I've got one deploy process that uses the lightning deploy strategy with redis and another deploy process that just uses s3, every time I deploy with the latter I miss the message that gives me a handy way to activate after checking that everything is good to go.

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People
@lukemelia @sd 
