### PR TITLE
Optionally ignore ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ A file matching this pattern will be uploaded to S3. The active key in S3 will b
 
 The ACL to apply to the objects.
 
+Set to `false` to not apply any ACLs.
+
 *Default:* `'public-read'`
 
 ### cacheControl
@@ -151,7 +153,7 @@ or Openstack Swift
 
 If `endpoint` set the `region` option will be ignored.
 
-*Default:* `[region].s3.amazonaws.com` 
+*Default:* `[region].s3.amazonaws.com`
 
 
 ### serverSideEncryption

--- a/index.js
+++ b/index.js
@@ -66,7 +66,6 @@ module.exports = {
         var options = {
           bucket: bucket,
           prefix: prefix,
-          acl: acl,
           cacheControl: cacheControl,
           filePattern: filePattern,
           filePath: filePath,
@@ -76,6 +75,10 @@ module.exports = {
           allowOverwrite: allowOverwrite,
           urlEncodeSourceObject: urlEncodeSourceObject
         };
+
+        if (acl) {
+          options.acl = acl;
+        }
 
         if (serverSideEncryption) {
           options.serverSideEncryption = serverSideEncryption;
@@ -99,11 +102,14 @@ module.exports = {
         var options = {
           bucket: bucket,
           prefix: prefix,
-          acl: acl,
           filePattern: filePattern,
           revisionKey: revisionKey,
           urlEncodeSourceObject: urlEncodeSourceObject,
         };
+
+        if (acl) {
+          options.acl = acl;
+        }
 
         if (serverSideEncryption) {
           options.serverSideEncryption = serverSideEncryption;

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -147,6 +147,16 @@ describe('s3-index plugin', function() {
           });
       });
 
+      it('filters acl when not defined', function() {
+        context.config['s3-index'].acl = false;
+        var promise = plugin.upload(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            assert.equal(Object.prototype.hasOwnProperty.call(s3Options, 'acl'), false, 'acl filtered correctly');
+          });
+      });
+
       it('passes cacheControl options based on the cacheControl option to the s3-abstraction', function() {
         var cacheControl = 'max-age=3600';
         context.config['s3-index'].cacheControl = cacheControl;
@@ -261,6 +271,16 @@ describe('s3-index plugin', function() {
         return assert.isFulfilled(promise)
           .then(function() {
             assert.equal(Object.prototype.hasOwnProperty.call(s3Options, 'serverSideEncryption'), false, 'serverSideEncryption filtered correctly');
+          });
+      });
+
+      it('filters acl when not defined', function() {
+        context.config['s3-index'].acl = false;
+        var promise = plugin.upload(context);
+
+        return assert.isFulfilled(promise)
+          .then(function() {
+            assert.equal(Object.prototype.hasOwnProperty.call(s3Options, 'acl'), false, 'acl filtered correctly');
           });
       });
 


### PR DESCRIPTION
## What Changed & Why
[Since April 2023, buckets by default have ACLs off](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/). This change allows ACLs to be ignored if set to false. This allows the plugin to work with the default bucket policy.

## Related issues
Link to related issues in this or other repositories (if any)

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)
