### PR TITLE
Handle empty s3 response

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 'latest',
     sourceType: 'module'
   },
   extends: 'eslint:recommended',

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -166,7 +166,7 @@ module.exports = CoreObject.extend({
     var revisionPrefix = joinUriSegments(prefix, options.filePattern + ":" + options.revisionKey);
 
     return listObjects({ Bucket: bucket, Prefix: revisionPrefix })
-      .then((response) => response.Contents.find((element) => element.Key === revisionPrefix));
+      .then((response) => response.Contents?.find((element) => element.Key === revisionPrefix));
   },
 
   fetchRevisions: function(options) {

--- a/tests/unit/lib/s3-test.js
+++ b/tests/unit/lib/s3-test.js
@@ -242,6 +242,15 @@ describe('s3', function() {
         });
     });
 
+    it('succeeds when revision key search returns no values', function() {
+      s3Client.listObjects = function(params, cb) {
+        cb(undefined, {});
+      };
+      var promise = subject.upload(options);
+
+      return assert.isFulfilled(promise);
+    });
+
     describe("when revisionKey was already uploaded", function() {
       beforeEach(function() {
         options.revisionKey = "123";


### PR DESCRIPTION
## What Changed & Why

After the update to AWS SDK v3 when searching for a revision the Contents on the response is not present if the revision hasn't been created yet. This seemed like the smallest change to fix the problem, and optional chaining is supported in Node 14, but I had to bump up the ecmaVersion in the eslint config to allow it.

Without this our deployed after updating to v4.0.1 have the error 
`TypeError: Cannot read properties of undefined (reading 'find') at ember-cli-deploy-s3-index@4.0.1/node_modules/ember-cli-deploy-s3-index/lib/s3.js:169:45`

Debugging this method, my response from AWS looks like:

```javascript
{
  '$metadata': {
    httpStatusCode: 200,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  },
  IsTruncated: false,
  Marker: '',
  MaxKeys: 1000,
}
```

I wasn't able to find anything in the AWS upgrade notes or in the API docs that explains this difference which is why I made the changes so small and didn't attempt to check if `Contents` exists or count the responses instead. I'm happy to do this another way if someone is more familiar with the S3 API calls here.

## Related issues
#138

## PR Checklist
- [x] Add tests

## People
@lukemelia  @saravanak
