### PR TITLE
Handle NotFound S3 Response

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -9,20 +9,15 @@ var readFile        = RSVP.denodeify(fs.readFile);
 var mime            = require('mime-types');
 var joinUriSegments = require('./util/join-uri-segments');
 
-function headObject(client, params) {
-  return new RSVP.Promise(function(resolve, reject) {
-    client.headObject(params, function(err, data) {
-      if (err && err.code === 'NotFound') {
-        return resolve();
-      }
-      else if (err) {
-        return reject(err);
-      }
-      else {
-        return resolve(data);
-      }
-    });
-  });
+async function headObject(client, params) {
+  try {
+    return await client.headObject(params);
+  } catch (err) {
+    if (err.name === 'NotFound') {
+      return;
+    }
+    throw err;
+  }
 }
 
 module.exports = CoreObject.extend({
@@ -37,7 +32,7 @@ module.exports = CoreObject.extend({
     this._plugin = plugin;
 
     var providedS3Client = plugin.readConfig("s3Client");
-    
+
 
     if (profile && !providedS3Client) {
       this._plugin.log("Using AWS profile from config", { verbose: true });
@@ -45,18 +40,18 @@ module.exports = CoreObject.extend({
     }
 
     if (endpoint) {
-      this._plugin.log('Using endpoint from config', { verbose: true });      
+      this._plugin.log('Using endpoint from config', { verbose: true });
     }
 
     this._client = providedS3Client || new S3(config);
-  
+
     if (endpoint) {
       this._client.config.endpoint = endpoint;
     }
     if (credentials) {
       this._client.config.credentials = credentials;
     }
-    
+
   },
 
   upload: function(options) {

--- a/tests/unit/lib/s3-test.js
+++ b/tests/unit/lib/s3-test.js
@@ -27,9 +27,9 @@ describe('s3', function() {
         cb(undefined, revisionsData);
       },
 
-      headObject: function(params, cb) {
+      headObject: async function(params, cb) {
         headParams = params;
-        cb(undefined, currentData);
+        return currentData;
       },
 
       copyObject: function(params, cb) {


### PR DESCRIPTION
## What Changed & Why
After the upgrade to AWS SDK V3 the headObject method needed to be refactored for cases where the key or bucket are missing and S3 returns a 404. In [V3 of the SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/) this is a [thrown error](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-s3/Class/NotFound/) that must be caught.

## Related issues
#138

## PR Checklist
- [x] Updated Tests

## People
@lukemelia @saravanak
